### PR TITLE
The newly deployed service won't receive traffic. This makes it possible

### DIFF
--- a/demo/cloudbuild.yaml
+++ b/demo/cloudbuild.yaml
@@ -7,6 +7,6 @@
    args: ['push', 'gcr.io/$PROJECT_ID/demo:$COMMIT_SHA']
  # Deploy container image to Cloud Run
  - name: 'gcr.io/cloud-builders/gcloud'
-   args: ['run', 'deploy', 'runservice', '--image', 'gcr.io/$PROJECT_ID/demo:$COMMIT_SHA', '--region', 'us-central1', '--platform', 'managed', '--allow-unauthenticated']
+   args: ['run', 'deploy', 'runservice', '--image', 'gcr.io/$PROJECT_ID/demo:$COMMIT_SHA', '--region', 'us-central1', '--platform', 'managed', '--allow-unauthenticated', '--no-traffic']
  images:
  - 'gcr.io/$PROJECT_ID/demo:$COMMIT_SHA'


### PR DESCRIPTION
for Canary test.